### PR TITLE
target: remove extra https prefix

### DIFF
--- a/sites/target.js
+++ b/sites/target.js
@@ -35,7 +35,7 @@ module.exports = {
     // TODO: implement price
     const price = undefined
 
-    const image = 'https:' + og($, 'image')
+    const image = og($, 'image')
 
     return { name, price, image }
   }


### PR DESCRIPTION
The image url already comes with an https prefix, adding it again results in broken images for Target links.